### PR TITLE
Implement tag only option attribute to avoid commit number

### DIFF
--- a/src/hunternif/jgitversion/JGitVersionTask.java
+++ b/src/hunternif/jgitversion/JGitVersionTask.java
@@ -25,12 +25,17 @@ import org.gitective.core.filter.commit.CommitCountFilter;
 public class JGitVersionTask extends Task {
 	private String dir;
 	private String property;
+	private boolean tagonly;
 	
 	public void setDir(String dir) {
 		this.dir = dir;
 	}
 	public void setProperty(String property) {
 		this.property = property;
+	}
+	
+	public void setTagonly(boolean tagonly) {
+		this.tagonly = tagonly;
 	}
 	
 	@Override
@@ -46,7 +51,7 @@ public class JGitVersionTask extends Task {
 		}
 	}
 	
-	public static String getProjectVersion(File repoDir) throws IOException, GitAPIException {
+	public String getProjectVersion(File repoDir) throws IOException, GitAPIException {
 		Git git = Git.open(repoDir);
 		Repository repo = git.getRepository();
 		
@@ -106,7 +111,7 @@ public class JGitVersionTask extends Task {
 		if (tagName.isEmpty()) {
 			version = "0";
 		}
-		version += tagName + "." + commitsSinceLastMasterTag;
+		version += tagName + ((!tagonly) ? "." + commitsSinceLastMasterTag : "");
 		
 		return version;
 	}


### PR DESCRIPTION
I had the need to remove the number of commit after the version number retrieved from the tag, so I've implemented a new option (tagonly) to avoid to have the commit number ...

If you find it useful you can include it in the original project ...
