### PR TITLE
Small Improvements: Support for Relative Paths and More Flexible Attribute

### DIFF
--- a/src/hunternif/jgitversion/JGitVersionTask.java
+++ b/src/hunternif/jgitversion/JGitVersionTask.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
+import org.apache.tools.ant.types.EnumeratedAttribute;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
@@ -23,9 +24,17 @@ import org.gitective.core.CommitUtils;
 import org.gitective.core.filter.commit.CommitCountFilter;
 
 public class JGitVersionTask extends Task {
+	
+	public static class BooleanOrAuto extends EnumeratedAttribute {
+		@Override
+		public String[] getValues() {
+			return new String[] { "true", "false", "auto" };
+		}
+	}
+	
 	private File dir;
 	private String property;
-	private boolean tagonly;
+	private BooleanOrAuto tagonly;
 	
 	public void setDir(File dir) {
 		this.dir = dir;
@@ -34,7 +43,7 @@ public class JGitVersionTask extends Task {
 		this.property = property;
 	}
 	
-	public void setTagonly(boolean tagonly) {
+	public void setTagonly(BooleanOrAuto tagonly) {
 		this.tagonly = tagonly;
 	}
 	
@@ -111,7 +120,19 @@ public class JGitVersionTask extends Task {
 		if (tagName.isEmpty()) {
 			version = "0";
 		}
-		version += tagName + ((!tagonly) ? "." + commitsSinceLastMasterTag : "");
+		
+		boolean tagonlyEvaluated = false;  // Default if attribute not set
+		if (tagonly != null) {
+			boolean isAuto = tagonly.getValue().equalsIgnoreCase("auto");
+			if (isAuto) {
+				tagonlyEvaluated = commitsSinceLastMasterTag == 0;
+			}
+			else {
+				tagonlyEvaluated = Boolean.parseBoolean(tagonly.getValue());
+			}
+		}
+		
+		version += tagName + ((!tagonlyEvaluated) ? "." + commitsSinceLastMasterTag : "");
 		
 		return version;
 	}

--- a/src/hunternif/jgitversion/JGitVersionTask.java
+++ b/src/hunternif/jgitversion/JGitVersionTask.java
@@ -23,11 +23,11 @@ import org.gitective.core.CommitUtils;
 import org.gitective.core.filter.commit.CommitCountFilter;
 
 public class JGitVersionTask extends Task {
-	private String dir;
+	private File dir;
 	private String property;
 	private boolean tagonly;
 	
-	public void setDir(String dir) {
+	public void setDir(File dir) {
 		this.dir = dir;
 	}
 	public void setProperty(String property) {
@@ -41,7 +41,7 @@ public class JGitVersionTask extends Task {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			String version = getProjectVersion(new File(dir));
+			String version = getProjectVersion(dir);
 			Project project = getProject();
 			if (project != null) {
 				project.setProperty(property, version);

--- a/test/hunternif/jgitversion/TestGit.java
+++ b/test/hunternif/jgitversion/TestGit.java
@@ -5,7 +5,7 @@ import java.io.File;
 public class TestGit {
 	public static void main(String[] args) {
 		try {
-			System.out.println(JGitVersionTask.getProjectVersion(new File(".")));
+			System.out.println(new JGitVersionTask().getProjectVersion(new File(".")));
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Changing the type of attribute "dir" from String to File. This way relative paths are handled correctly.
Attribute tagonly can also be "auto" now. In this case the number of commits since last master tag is only included if not zero.